### PR TITLE
Enables the client to send an optional keepAlive via WS Ping

### DIFF
--- a/src/main/scala/com/twitter/finagle/HttpWebSocket.scala
+++ b/src/main/scala/com/twitter/finagle/HttpWebSocket.scala
@@ -6,7 +6,7 @@ import com.twitter.finagle.dispatch.{SerialServerDispatcher, SerialClientDispatc
 import com.twitter.finagle.netty3._
 import com.twitter.finagle.server._
 import com.twitter.concurrent.Offer
-import com.twitter.util.Future
+import com.twitter.util.{Duration, Future}
 import java.net.{SocketAddress, URI}
 
 trait WebSocketRichClient {
@@ -19,8 +19,11 @@ trait WebSocketRichClient {
   def open(out: Offer[String], binaryOut: Offer[Array[Byte]], uri: String): Future[WebSocket] =
     open(out, binaryOut, new URI(uri))
 
-  def open(out: Offer[String], binaryOut: Offer[Array[Byte]], uri: URI): Future[WebSocket] = {
-    val socket = WebSocket(messages = out, binaryMessages = binaryOut, uri = uri)
+  def open(out: Offer[String], binaryOut: Offer[Array[Byte]], uri: String, keepAlive: Option[Duration]): Future[WebSocket] =
+    open(out, binaryOut, new URI(uri), keepAlive = keepAlive)
+
+  def open(out: Offer[String], binaryOut: Offer[Array[Byte]], uri: URI, keepAlive: Option[Duration] = None): Future[WebSocket] = {
+    val socket = WebSocket(messages = out, binaryMessages = binaryOut, uri = uri, keepAlive = keepAlive)
     val addr = uri.getHost + ":" + uri.getPort
     HttpWebSocket.newClient(addr).toService(socket)
   }

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocket.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocket.scala
@@ -1,9 +1,10 @@
 package com.twitter.finagle.websocket
 
 import com.twitter.concurrent.Offer
-import com.twitter.util.{Future, Promise}
+import com.twitter.util.{Future, Promise, Duration}
 import java.net.URI
 import org.jboss.netty.handler.codec.http.websocketx.WebSocketVersion
+import org.jboss.netty.handler.codec.http.websocketx.WebSocketFrame
 import java.net.SocketAddress
 
 case class WebSocket(
@@ -14,4 +15,5 @@ case class WebSocket(
   remoteAddress: SocketAddress = new SocketAddress {},
   version: WebSocketVersion = WebSocketVersion.V13,
   onClose: Future[Unit] = new Promise[Unit],
-  close: () => Unit = { () => () })
+  close: () => Unit = { () => () },
+  keepAlive: Option[Duration] = None)

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -214,10 +214,9 @@ class WebSocketClientHandler extends WebSocketHandler {
 
             // initiate the keep-alive
             for(interval <- sock.keepAlive) {
-              timer.schedule(interval) {
+              keepAliveTask = Option(timer.schedule(interval) {
                 ctx.getChannel.write(new PingWebSocketFrame())
-              }
-
+              })
             }
 
             e.getFuture.setSuccess()


### PR DESCRIPTION
WebSocket connections are typically set-up to remain connected to the server. Proxies or other middleboxes may shut down the TCP connection after some inactivity. This PR enables the client to send WebSocket Ping Frames at a fixed interval to maintain the client connection.
