### PR TITLE
Drag finagle-websockets screaming into the future

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ import Keys._
 import scoverage.ScoverageSbtPlugin
 
 object FinagleWebsocket extends Build {
-  val libVersion = "6.27.0"
+  val libVersion = "6.33.0"
 
   val baseSettings = Defaults.defaultSettings ++ Seq(
     libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")

--- a/src/main/scala/com/twitter/finagle/websocket/Filters.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Filters.scala
@@ -1,0 +1,28 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.finagle.{ Service, SimpleFilter }
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.util.{ Duration, Future, Time, Timer }
+
+case class KeepAlive(
+  interval: Duration,
+  timer: Timer = DefaultTimer.twitter
+) extends SimpleFilter[WebSocketStart, WebSocket] {
+  def apply(req: WebSocketStart, svc: Service[WebSocketStart, WebSocket]): Future[WebSocket] =
+    svc(req) map { sock =>
+      val task = timer.schedule(interval) { sock.write(WebSocketFrame.Ping()) }
+      sock.closed foreach { _ => task.cancel() }
+      sock
+    }
+}
+
+object PingPong extends SimpleFilter[WebSocket, Unit] {
+  def apply(sock: WebSocket, svc: Service[WebSocket, Unit]): Future[Unit] = {
+    sock.stream foreach {
+      case WebSocketFrame.Ping(data) => sock.write(WebSocketFrame.Pong(data))
+      case _ =>
+    }
+    svc(sock)
+  }
+}
+

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketCodec.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketCodec.scala
@@ -4,9 +4,9 @@ import com.twitter.finagle.{Codec, CodecFactory}
 import org.jboss.netty.channel.{ChannelPipelineFactory, Channels}
 import org.jboss.netty.handler.codec.http._
 
-case class WebSocketCodec() extends CodecFactory[WebSocket, WebSocket] {
+case class WebSocketCodec() extends CodecFactory[Any, Any] {
   def server = Function.const {
-    new Codec[WebSocket, WebSocket] {
+    new Codec[Any, Any] {
       def pipelineFactory = new ChannelPipelineFactory {
         def getPipeline = {
           val pipeline = Channels.pipeline()
@@ -20,7 +20,7 @@ case class WebSocketCodec() extends CodecFactory[WebSocket, WebSocket] {
   }
 
   def client = Function.const {
-    new Codec[WebSocket, WebSocket] {
+    new Codec[Any, Any] {
       def pipelineFactory = new ChannelPipelineFactory {
         def getPipeline = {
           val pipeline = Channels.pipeline()

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketFrame.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketFrame.scala
@@ -1,0 +1,49 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.io.Buf
+
+sealed trait WebSocketFrame extends Buf {
+  val underlying: Buf
+
+  def write(output: Array[Byte], off: Int): Unit =
+    underlying.write(output, off)
+
+  def length: Int =
+    underlying.length
+
+  def slice(from: Int, until: Int): Buf =
+    underlying.slice(from, until)
+
+  def unsafeByteArrayBuf: Option[Buf.ByteArray] = underlying match {
+    case buf: Buf.ByteArray => Some(buf)
+    case _ => None
+  }
+}
+
+object WebSocketFrame {
+  case class Text(underlying: Buf) extends WebSocketFrame
+
+  object Text {
+    def apply(str: String): Text = Text(Buf.Utf8(str))
+
+    def unapply(frame: Buf): Option[String] = frame match {
+      case f: Text => val Buf.Utf8(str) = f.underlying; Some(str)
+      case _ => None
+    }
+  }
+
+  case class Binary(underlying: Buf) extends WebSocketFrame
+
+  case class Ping(underlying: Buf = Buf.Empty) extends WebSocketFrame
+
+  case class Pong(underlying: Buf = Buf.Empty) extends WebSocketFrame
+
+  sealed abstract class Close(val code: Int) extends WebSocketFrame {
+    val underlying = Buf.Empty
+    val reason: Option[String]
+  }
+  case class NormalClose(reason: Option[String] = None) extends Close(1000)
+  case class GoingAway(reason: Option[String] = None) extends Close(1001)
+  case class Error(reason: Option[String] = None) extends Close(1002)
+  case class Invalid(reason: Option[String] = None) extends Close(1003)
+}

--- a/src/test/scala/com/twitter/finagle/websocket/WebSocketTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/WebSocketTest.scala
@@ -1,0 +1,33 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.io.Buf
+import java.util.Arrays
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WebSocketTest extends FunSuite {
+  test("WebSocketFrame") {
+    val txt = WebSocketFrame.Text("foo")
+    val WebSocketFrame.Text(str) = txt
+    assert(str === txt)
+
+    val buf = Buf.ByteArray(0x01: Byte)
+    val binFrame = WebSocketFrame.Binary(buf)
+    val WebSocketFrame.Binary(out) = binFrame
+    assert(out === buf)
+
+    val buf2 = Buf.ByteArray(0x01, 0x02, 0x03, 0x04)
+    val bin = WebSocketFrame.Binary(buf2)
+    assert(bin.length === buf2.length)
+    assert(bin.slice(0, 2) === buf2.slice(0, 2))
+
+    val binArr = new Array[Byte](4)
+    bin.write(binArr, 0)
+    val buf2Arr = new Array[Byte](4)
+    buf2.write(buf2Arr, 0)
+
+    assert(Arrays.equals(binArr, buf2Arr))
+  }
+}


### PR DESCRIPTION
Remove dependency on Offer/Broker. Use Reader/Writer and AsyncStream instead.
Combine text and binary streams. This also leaves the door open to passing other frames to the service and handling ping/pong (and keep alive) in filters.

I think this is a decent start.

pinging @olix0r for review
