### PR TITLE
server: modernize websockets

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ import Keys._
 import scoverage.ScoverageSbtPlugin
 
 object FinagleWebsocket extends Build {
-  val libVersion = "6.27.0"
+  val libVersion = "6.34.0"
 
   val baseSettings = Defaults.defaultSettings ++ Seq(
     libraryDependencies ++= Seq(

--- a/src/main/scala/com/twitter/finagle/WebSocket.scala
+++ b/src/main/scala/com/twitter/finagle/WebSocket.scala
@@ -1,0 +1,45 @@
+package com.twitter.finagle
+
+import com.twitter.finagle.param.{Label, ProtocolLibrary, Stats}
+import com.twitter.finagle.server.{Listener, StdStackServer, StackServer}
+import com.twitter.finagle.transport.Transport
+import com.twitter.finagle.websocket.{Netty3, Request, Response, ServerDispatcher}
+import com.twitter.util.Closable
+import java.net.SocketAddress
+
+object Websocket extends Server[Request, Response] {
+  case class Server(
+      stack: Stack[ServiceFactory[Request, Response]] = StackServer.newStack,
+      params: Stack.Params = StackServer.defaultParams + ProtocolLibrary("ws"))
+    extends StdStackServer[Request, Response, Server] {
+
+    protected type In = Any
+    protected type Out = Any
+
+    protected def newListener(): Listener[In, Out] =
+      Netty3.newListener(params)
+
+    private[this] val statsReceiver = {
+      val Stats(sr) = params[Stats]
+      sr.scope("websocket")
+    }
+
+    protected def newDispatcher(
+      transport: Transport[In, Out],
+      service: Service[Request, Response]
+    ): Closable =
+        new ServerDispatcher(transport, service, statsReceiver)
+
+    protected def copy1(
+      stack: Stack[ServiceFactory[Request, Response]] = this.stack,
+      params: Stack.Params = this.params
+    ): Server = copy(stack, params)
+  }
+
+  val server: Websocket.Server = Server()
+
+  def serve(
+    addr: SocketAddress,
+    factory: ServiceFactory[Request, Response]
+  ): ListeningServer = server.serve(addr, factory)
+}

--- a/src/main/scala/com/twitter/finagle/websocket/Frame.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Frame.scala
@@ -13,7 +13,10 @@ import com.twitter.io.Buf
  * [1]: https://tools.ietf.org/html/rfc6455
  */
 sealed trait Frame
-case class Text(text: String) extends Frame
-case class Binary(buf: Buf) extends Frame
-case class Ping(buf: Buf) extends Frame
-case class Pong(buf: Buf) extends Frame
+
+object Frame {
+  case class Text(text: String) extends Frame
+  case class Binary(buf: Buf) extends Frame
+  case class Ping(buf: Buf) extends Frame
+  case class Pong(buf: Buf) extends Frame
+}

--- a/src/main/scala/com/twitter/finagle/websocket/Frame.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Frame.scala
@@ -1,0 +1,7 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.io.Buf
+
+sealed trait Frame
+case class Text(text: String) extends Frame
+case class Binary(buf: Buf) extends Frame

--- a/src/main/scala/com/twitter/finagle/websocket/Frame.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Frame.scala
@@ -2,6 +2,16 @@ package com.twitter.finagle.websocket
 
 import com.twitter.io.Buf
 
+/**
+ * Represents various WebSocket frames.
+ *
+ * This is a simplification of the frame types described in RFC6455[1]. Notably
+ * absent are Continuation and Close. Close is handled directly in the
+ * pipeline, initiating the close handshake. Continuations are treated as
+ * Binary frames, which means we lose the ability to determine fragmentation.
+ *
+ * [1]: https://tools.ietf.org/html/rfc6455
+ */
 sealed trait Frame
 case class Text(text: String) extends Frame
 case class Binary(buf: Buf) extends Frame

--- a/src/main/scala/com/twitter/finagle/websocket/Frame.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Frame.scala
@@ -5,3 +5,5 @@ import com.twitter.io.Buf
 sealed trait Frame
 case class Text(text: String) extends Frame
 case class Binary(buf: Buf) extends Frame
+case class Ping(buf: Buf) extends Frame
+case class Pong(buf: Buf) extends Frame

--- a/src/main/scala/com/twitter/finagle/websocket/Netty3.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Netty3.scala
@@ -1,0 +1,22 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.finagle.Stack
+import com.twitter.finagle.netty3.Netty3Listener
+import com.twitter.finagle.server.Listener
+import org.jboss.netty.channel.{Channels, ChannelPipelineFactory}
+import org.jboss.netty.handler.codec.http.{HttpResponseEncoder, HttpRequestDecoder}
+
+private[finagle] object Netty3 {
+  private def serverPipeline = {
+    val pipeline = Channels.pipeline()
+    pipeline.addLast("decoder", new HttpRequestDecoder)
+    pipeline.addLast("encoder", new HttpResponseEncoder)
+    pipeline.addLast("handler", new WebSocketServerHandler)
+    pipeline
+  }
+
+  def newListener[In, Out](params: Stack.Params): Listener[In, Out] =
+    Netty3Listener(new ChannelPipelineFactory {
+      def getPipeline() = serverPipeline
+    }, params)
+}

--- a/src/main/scala/com/twitter/finagle/websocket/Request.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Request.scala
@@ -1,5 +1,10 @@
 package com.twitter.finagle.websocket
 
 import com.twitter.concurrent.AsyncStream
+import java.net.URI
+import scala.collection.immutable
 
-case class Request(messages: AsyncStream[Frame])
+case class Request(
+    uri: URI,
+    headers: immutable.Map[String, String],
+    messages: AsyncStream[Frame])

--- a/src/main/scala/com/twitter/finagle/websocket/Request.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Request.scala
@@ -1,0 +1,5 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.concurrent.AsyncStream
+
+case class Request(messages: AsyncStream[Frame])

--- a/src/main/scala/com/twitter/finagle/websocket/Request.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Request.scala
@@ -1,10 +1,11 @@
 package com.twitter.finagle.websocket
 
 import com.twitter.concurrent.AsyncStream
-import java.net.URI
+import java.net.{SocketAddress, URI}
 import scala.collection.immutable
 
 case class Request(
     uri: URI,
     headers: immutable.Map[String, String],
+    remoteAddress: SocketAddress,
     messages: AsyncStream[Frame])

--- a/src/main/scala/com/twitter/finagle/websocket/Response.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/Response.scala
@@ -1,0 +1,6 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.concurrent.AsyncStream
+
+case class Response(messages: AsyncStream[Frame])
+

--- a/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
@@ -1,0 +1,58 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.Service
+import com.twitter.finagle.netty3.{BufChannelBuffer, ChannelBufferBuf}
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.transport.Transport
+import com.twitter.io.Buf
+import com.twitter.util.{Closable, Future, Time}
+import org.jboss.netty.handler.codec.http.websocketx._
+
+private[finagle] class ServerDispatcher(
+    trans: Transport[Any, Any],
+    service: Service[Request, Response],
+    stats: StatsReceiver)
+  extends Closable {
+
+  import ServerDispatcher._
+
+  private[this] def messages(): AsyncStream[Any] =
+    AsyncStream.fromFuture(trans.read()) ++ messages()
+
+  private[this] val request = Request(messages.map(fromNetty))
+
+  service(request).flatMap { response =>
+    response.messages
+      .map(toNetty)
+      .foreachF(trans.write)
+      .ensure(trans.close())
+  }
+
+  def close(deadline: Time): Future[Unit] =
+    trans.close()
+}
+
+private object ServerDispatcher {
+  def fromNetty(m: Any): Frame = m match {
+    case text: TextWebSocketFrame =>
+      Text(text.getText)
+
+    case cont: ContinuationWebSocketFrame =>
+      Text(cont.getText)
+
+    case bin: BinaryWebSocketFrame =>
+      Binary(new ChannelBufferBuf(bin.getBinaryData))
+
+    // TODO don't do this
+    case _ => throw new Exception("unknown frame")
+  }
+
+  def toNetty(frame: Frame): WebSocketFrame = frame match {
+    case Text(message) =>
+      new TextWebSocketFrame(message)
+
+    case Binary(buf) =>
+      new BinaryWebSocketFrame(BufChannelBuffer(buf))
+  }
+}

--- a/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
@@ -26,9 +26,11 @@ private[finagle] class ServerDispatcher(
   // The first item is a HttpRequest.
   trans.read().flatMap {
     case req: HttpRequest =>
+      println("Got HTTP Request")
       val uri = new URI(req.getUri)
       val headers = req.headers.asScala.map(e => e.getKey -> e.getValue).toMap
       service(Request(uri, headers, messages)).flatMap { response =>
+        println("Got HTTP Response")
         response.messages
           .map(toNetty)
           .foreachF(trans.write)

--- a/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
@@ -26,11 +26,9 @@ private[finagle] class ServerDispatcher(
   // The first item is a HttpRequest.
   trans.read().flatMap {
     case req: HttpRequest =>
-      println("Got HTTP Request")
       val uri = new URI(req.getUri)
       val headers = req.headers.asScala.map(e => e.getKey -> e.getValue).toMap
       service(Request(uri, headers, messages)).flatMap { response =>
-        println("Got HTTP Response")
         response.messages
           .map(toNetty)
           .foreachF(trans.write)

--- a/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
@@ -7,7 +7,7 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.finagle.transport.Transport
 import com.twitter.io.Buf
 import com.twitter.util.{Closable, Future, Time}
-import java.net.URI
+import java.net.{SocketAddress, URI}
 import org.jboss.netty.handler.codec.http.HttpRequest
 import org.jboss.netty.handler.codec.http.websocketx._
 import scala.collection.JavaConverters._
@@ -25,10 +25,10 @@ private[finagle] class ServerDispatcher(
 
   // The first item is a HttpRequest.
   trans.read().flatMap {
-    case req: HttpRequest =>
+    case (req: HttpRequest, addr: SocketAddress) =>
       val uri = new URI(req.getUri)
       val headers = req.headers.asScala.map(e => e.getKey -> e.getValue).toMap
-      service(Request(uri, headers, messages)).flatMap { response =>
+      service(Request(uri, headers, addr, messages)).flatMap { response =>
         response.messages
           .map(toNetty)
           .foreachF(trans.write)

--- a/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/ServerDispatcher.scala
@@ -45,6 +45,8 @@ private[finagle] class ServerDispatcher(
 }
 
 private object ServerDispatcher {
+  import Frame._
+
   def fromNetty(m: Any): Frame = m match {
     case text: TextWebSocketFrame =>
       Text(text.getText)

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -97,6 +97,7 @@ private[finagle] class WebSocketServerHandler extends SimpleChannelUpstreamHandl
             wsFactory.sendUnsupportedWebSocketVersionResponse(ctx.getChannel)
           case Some(ref) =>
             ref.handshake(ctx.getChannel, req)
+            Channels.fireMessageReceived(ctx, req)
         }
 
       case frame: CloseWebSocketFrame =>

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -102,9 +102,6 @@ private[finagle] class WebSocketServerHandler extends SimpleChannelUpstreamHandl
       case frame: CloseWebSocketFrame =>
         handshaker.foreach(_.close(ctx.getChannel, frame))
 
-      case frame: PingWebSocketFrame =>
-        ctx.getChannel.write(new PongWebSocketFrame(frame.getBinaryData))
-
       case frame: WebSocketFrame =>
         Channels.fireMessageReceived(ctx, frame)
 

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -97,7 +97,8 @@ private[finagle] class WebSocketServerHandler extends SimpleChannelUpstreamHandl
             wsFactory.sendUnsupportedWebSocketVersionResponse(ctx.getChannel)
           case Some(ref) =>
             ref.handshake(ctx.getChannel, req)
-            Channels.fireMessageReceived(ctx, req)
+            val addr = ctx.getChannel.getRemoteAddress
+            Channels.fireMessageReceived(ctx, (req, addr))
         }
 
       case frame: CloseWebSocketFrame =>

--- a/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
+++ b/src/main/scala/com/twitter/finagle/websocket/WebSocketHandler.scala
@@ -82,10 +82,10 @@ class WebSocketHandler extends SimpleChannelHandler {
   }
 }
 
-class WebSocketServerHandler extends WebSocketHandler {
+private[finagle] class WebSocketServerHandler extends SimpleChannelUpstreamHandler {
   private[this] var handshaker: Option[WebSocketServerHandshaker] = None
 
-  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) = {
+  override def messageReceived(ctx: ChannelHandlerContext, e: MessageEvent) =
     e.getMessage match {
       case req: HttpRequest =>
         val scheme = if(req.getUri.startsWith("wss")) "wss" else "ws"
@@ -95,64 +95,23 @@ class WebSocketServerHandler extends WebSocketHandler {
         handshaker match {
           case None =>
             wsFactory.sendUnsupportedWebSocketVersionResponse(ctx.getChannel)
-          case Some(h) =>
-            h.handshake(ctx.getChannel, req)
-
-            def close() { Channels.close(ctx.getChannel) }
-
-            val webSocket = WebSocket(
-              messages = messagesBroker.recv,
-              binaryMessages = binaryMessagesBroker.recv,
-              uri = new URI(req.getUri),
-              headers = req.headers.map(e => e.getKey -> e.getValue).toMap,
-              remoteAddress = ctx.getChannel.getRemoteAddress,
-              onClose = closer,
-              close = close)
-
-            Channels.fireMessageReceived(ctx, webSocket)
+          case Some(ref) =>
+            ref.handshake(ctx.getChannel, req)
         }
 
       case frame: CloseWebSocketFrame =>
-        handshaker foreach { _.close(ctx.getChannel, frame) }
+        handshaker.foreach(_.close(ctx.getChannel, frame))
 
       case frame: PingWebSocketFrame =>
         ctx.getChannel.write(new PongWebSocketFrame(frame.getBinaryData))
 
-      case frame: TextWebSocketFrame =>
-        val ch = ctx.getChannel
-        ch.setReadable(false)
-        (messagesBroker ! frame.getText) ensure { ch.setReadable(true) }
-
-      case frame: BinaryWebSocketFrame =>
-        val ch = ctx.getChannel
-        ch.setReadable(false)
-        (binaryMessagesBroker ! frame.getBinaryData.array) ensure { ch.setReadable(true) }
+      case frame: WebSocketFrame =>
+        Channels.fireMessageReceived(ctx, frame)
 
       case invalid =>
         Channels.fireExceptionCaught(ctx,
-          new IllegalArgumentException("invalid message \"%s\"".format(invalid)))
+          new IllegalArgumentException(s"invalid message: $invalid"))
     }
-  }
-
-  override def writeRequested(ctx: ChannelHandlerContext, e: MessageEvent) = {
-    e.getMessage match {
-      case sock: WebSocket =>
-        write(ctx, sock)
-
-      case _: HttpResponse =>
-        ctx.sendDownstream(e)
-
-      case _: PongWebSocketFrame =>
-        ctx.sendDownstream(e)
-
-      case _: CloseWebSocketFrame =>
-        ctx.sendDownstream(e)
-
-      case invalid =>
-        Channels.fireExceptionCaught(ctx,
-          new IllegalArgumentException("invalid message \"%s\"".format(invalid)))
-    }
-  }
 }
 
 class WebSocketClientHandler extends WebSocketHandler {

--- a/src/test/scala/com/twitter/finagle/websocket/EndToEndTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/EndToEndTest.scala
@@ -29,6 +29,7 @@ class EndToEndTest extends FunSuite {
             val binary = Buf.ByteArray.Owned.extract(buf)
             synchronized { binaryResult ++= binary }
             latch.countDown()
+          case _ =>
         }
         Future.value(Response(req.messages))
       }

--- a/src/test/scala/com/twitter/finagle/websocket/EndToEndTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/EndToEndTest.scala
@@ -1,12 +1,14 @@
 package com.twitter.finagle.websocket
 
-import com.twitter.conversions.time._
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.FunSuite
-import org.junit.runner.RunWith
 import com.twitter.concurrent.Broker
+import com.twitter.conversions.time._
+import com.twitter.finagle
 import com.twitter.finagle.{HttpWebSocket, Service}
+import com.twitter.io.Buf
 import com.twitter.util._
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
 import scala.collection.mutable.ArrayBuffer
 
 @RunWith(classOf[JUnitRunner])
@@ -17,20 +19,18 @@ class EndToEndTest extends FunSuite {
     val addr = RandomSocket()
     val latch = new CountDownLatch(10)
 
-    HttpWebSocket.serve(addr, new Service[WebSocket, WebSocket] {
-      def apply(req: WebSocket): Future[WebSocket] = {
-        val outgoing = new Broker[String]
-        val binaryOutgoing = new Broker[Array[Byte]]
-        val socket = req.copy(messages = outgoing.recv, binaryMessages = binaryOutgoing.recv)
-        req.messages foreach { msg =>
-          synchronized { result += msg }
-          latch.countDown()
+    finagle.Websocket.serve(addr, new Service[Request, Response] {
+      def apply(req: Request): Future[Response] = {
+        req.messages.foreach {
+          case Text(msg) =>
+            synchronized { result += msg }
+            latch.countDown()
+          case Binary(buf) =>
+            val binary = Buf.ByteArray.Owned.extract(buf)
+            synchronized { binaryResult ++= binary }
+            latch.countDown()
         }
-        req.binaryMessages foreach { binary =>
-          synchronized { binaryResult ++= binary }
-          latch.countDown()
-        }
-        Future.value(socket)
+        Future.value(Response(req.messages))
       }
     })
 

--- a/src/test/scala/com/twitter/finagle/websocket/EndToEndTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/EndToEndTest.scala
@@ -13,6 +13,8 @@ import scala.collection.mutable.ArrayBuffer
 
 @RunWith(classOf[JUnitRunner])
 class EndToEndTest extends FunSuite {
+  import Frame._
+
   test("multi client") {
     var result = ""
     val binaryResult = ArrayBuffer.empty[Byte]

--- a/src/test/scala/com/twitter/finagle/websocket/ServerDispatcherTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/ServerDispatcherTest.scala
@@ -1,0 +1,35 @@
+package com.twitter.finagle.websocket
+
+import com.twitter.concurrent.AsyncQueue
+import com.twitter.conversions.time._
+import com.twitter.finagle.{Service, Status}
+import com.twitter.finagle.stats.DefaultStatsReceiver
+import com.twitter.finagle.transport.{QueueTransport, Transport}
+import com.twitter.util.{Await, Future}
+import org.junit.runner.RunWith
+import org.jboss.netty.handler.codec.http._
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ServerDispatcherTest extends FunSuite {
+  import ServerDispatcherTest._
+
+  val echo = Service.mk { req: Request => Future.value(Response(req.messages)) }
+
+  test("invalid message") {
+    val (in, out) = mkPair[Any, Any]
+    val disp = new ServerDispatcher(out, echo, DefaultStatsReceiver)
+    in.write("invalid")
+    Await.ready(out.onClose)
+    assert(out.status == Status.Closed)
+  }
+}
+
+object ServerDispatcherTest {
+  def mkPair[A,B] = {
+    val inq = new AsyncQueue[A]
+    val outq = new AsyncQueue[B]
+    (new QueueTransport[A, B](inq, outq), new QueueTransport[B, A](outq, inq))
+  }
+}

--- a/src/test/scala/com/twitter/finagle/websocket/ServerDispatcherTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/ServerDispatcherTest.scala
@@ -6,6 +6,7 @@ import com.twitter.finagle.{Service, Status}
 import com.twitter.finagle.stats.DefaultStatsReceiver
 import com.twitter.finagle.transport.{QueueTransport, Transport}
 import com.twitter.util.{Await, Future}
+import java.net.SocketAddress
 import org.junit.runner.RunWith
 import org.jboss.netty.handler.codec.http._
 import org.jboss.netty.handler.codec.http.websocketx._
@@ -33,7 +34,9 @@ class ServerDispatcherTest extends FunSuite {
   test("valid message then invalid") {
     val (in, out) = mkPair[Any, Any]
     val disp = new ServerDispatcher(out, echo, DefaultStatsReceiver)
-    in.write(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"))
+    val req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/")
+    val addr = new SocketAddress{}
+    in.write((req, addr))
     in.write(new TextWebSocketFrame("hello"))
     val frame = Await.result(in.read(), 1.second)
     assert(frame.asInstanceOf[TextWebSocketFrame].getText == "hello")

--- a/src/test/scala/com/twitter/finagle/websocket/ServerDispatcherTest.scala
+++ b/src/test/scala/com/twitter/finagle/websocket/ServerDispatcherTest.scala
@@ -18,8 +18,6 @@ class ServerDispatcherTest extends FunSuite {
 
   val echo = new Service[Request, Response] {
     def apply(req: Request): Future[Response] = {
-      println("service: got request")
-      req.messages.foreach(println)
       Future.value(Response(req.messages))
     }
   }


### PR DESCRIPTION
Move off Offer/Broker, preferring AsyncStream.

In this model, servers receive an AsyncStream representing the frames of an incoming WebSocket client. The server responds with an AsyncStream of frames to be written to the client. When the response ends, the dispatcher knows to close the transport. This has the effect of discarding incoming frames.

Still working on (highest to lowest priority):
- [x] Update tests
- [x] Docs and comments
- [x] Get feedback for API for Request and Response

Related: #10 
