### PR TITLE
Added an example with an echo server and a console client

### DIFF
--- a/examples/src/main/scala/ConsoleClient.scala
+++ b/examples/src/main/scala/ConsoleClient.scala
@@ -1,0 +1,54 @@
+package com.twitter.finagle.websocket.examples
+
+import com.twitter.app.App
+import com.twitter.concurrent.AsyncStream
+import com.twitter.finagle.{Service, Websocket}
+import com.twitter.finagle.util.DefaultTimer
+import com.twitter.finagle.websocket._
+import com.twitter.util.{Await, Future, FuturePool, Promise}
+import java.net.{URI, SocketAddress}
+import io.StdIn
+
+object ConsoleClient
+extends App {
+  import com.twitter.conversions.time._
+  implicit val timer = DefaultTimer.twitter
+
+  val server = flag("server", "127.0.0.1:10001", "Host and port where the server listens")
+  val pool = FuturePool.unboundedPool
+
+  def readLine: AsyncStream[String] = {
+    val textF = pool { StdIn.readLine }
+      .flatMap { text =>
+        if(text == null || text.isEmpty)
+          Future.exception(new Exception("End of Stream"))
+        else Future.value(text)
+      }
+
+      AsyncStream.fromFuture(textF) ++ readLine
+  }
+
+  def main() {
+    val client: Service[Request, Response] = Websocket.client
+      .newService(server(), "console-client")
+
+    val input: AsyncStream[Frame] = readLine.map(Frame.Text(_))
+
+    val req = Request(new URI("/"), Map.empty, new SocketAddress{}, input)
+
+    val respF: Future[Response] = client(req)
+
+    respF.map { resp =>
+      resp.messages.foreach {
+        msg => println(s"Echo $msg")
+      }
+
+      resp
+    }
+
+    Await.ready(input.force)
+
+    client.close()
+  }
+
+}

--- a/examples/src/main/scala/EchoServer.scala
+++ b/examples/src/main/scala/EchoServer.scala
@@ -1,0 +1,48 @@
+package com.twitter.finagle.websocket.examples
+
+import com.twitter.app.App
+import com.twitter.finagle.{Service, Websocket, ServiceFactory, ClientConnection}
+import com.twitter.finagle.websocket._
+import com.twitter.util.{Await, Future, Time}
+
+
+object EchoServer
+extends App {
+  val bind = flag("bind", "127.0.0.1:10001", "Host and port where the server listens")
+
+  def service = new Service[Request, Response] {
+    def apply(req: Request): Future[Response] = {
+      Future(Response(req.messages.map {
+        case frame @ Frame.Text(data) =>
+          println("Text: " + data)
+          frame
+        case frame @ Frame.Binary(buf) => frame
+        case frame @ Frame.Ping(_) => frame
+        case frame @ Frame.Pong(_) => frame
+      }))
+    }
+  }
+
+  val factory = new ServiceFactory[Request, Response] {
+    def apply(conn: ClientConnection): Future[Service[Request, Response]] = {
+      println(s"Accepted connection $conn")
+
+      conn.onClose.map { _ => println(s"Closing $conn") }
+
+      Future.value(service)
+    }
+
+    def close(deadline:Time) = Future.Done
+  }
+
+  def main() {
+    val server = Websocket.server
+      .withLabel("echo-server")
+      .serve(bind(), factory)
+
+    Await.ready(server)
+
+    Await.ready(server.close())
+  }
+
+}

--- a/examples/src/main/scala/Proxy.scala
+++ b/examples/src/main/scala/Proxy.scala
@@ -1,0 +1,49 @@
+package com.twitter.finagle.websocket.examples
+
+import com.twitter.app.App
+import com.twitter.finagle.{Service, Websocket, ServiceFactory, ClientConnection}
+import com.twitter.finagle.websocket._
+import com.twitter.util.{Await, Future, Time}
+
+
+object ProxyServer
+extends App {
+  val bind = flag("bind", "127.0.0.1:10010", "Host and port where the proxy listens")
+  val server = flag("server", "127.0.0.1:10001", "Host and port where the server listens")
+
+  class ProxyService(client:Service[Request, Response])
+  extends Service[Request, Response] {
+    def apply(req: Request): Future[Response] = {
+      // connect the messages coming from the request with the messages written
+      // to the client and vice versa, i.e. we forward the request
+      client(req)
+    }
+  }
+
+  val factory = new ServiceFactory[Request, Response] {
+    def apply(conn: ClientConnection): Future[Service[Request, Response]] = {
+      println(s"Accepted proxy session $conn")
+      val client: Service[Request, Response] = Websocket.client
+        .newService(server(), "proxy-client")
+
+      conn.onClose
+        .flatMap { _ => client.close() }
+        .onSuccess { _ => println(s"Closed roxy session $conn") }
+
+      Future.value(new ProxyService(client))
+    }
+
+    def close(deadline:Time) = Future.Done
+  }
+
+  def main() {
+    val server = Websocket.server
+      .withLabel("proxy-server")
+      .serve(bind(), factory)
+
+    Await.ready(server)
+
+    Await.ready(server.close())
+  }
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,4 +56,13 @@ object FinagleWebsocket extends Build {
       buildSettings ++
       publishSettings
   ).configs(IntegrationTest)
+
+  lazy val examples = Project(
+    id = "finagle-websocket-examples",
+    base = file("examples"),
+    settings =
+      baseSettings ++
+      buildSettings
+  ).dependsOn(finagleWebsocket)
+
 }


### PR DESCRIPTION
Started on a new examples sub-project which can be used to showcase how to use finagle-websocket and as a way to try out the new API. If this does not belong in the main repo, please let me know.

This commit contains a console client that reads a line of text from stdin and sends it to an echo server. The server uses a ServiceFactory to keep track of websocket sessions.

I have a couple of points on the API:
- It took some time to get used to AsyncStream, but after some trial and error I think it is better compared to the Offer/Broker approach.
- When creating the client side Request, the SocketAddress is either set to `null` (from the other examples) or a `new SocketAddress {}`. Could we swap the input argument and provide a default value instead since this is more interesting to have access to on the server side?
- In the example, the ServiceFactory is used to get access to the ClientConnection for reporting on when the connection closes. Is there another way of doing this or is it recommended to use a ServiceFactory? An alternative would be to extend the request with an onClose promise as was done before, what are the trade-offs for doing so?
